### PR TITLE
Silence Dependabot

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,28 +4,28 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-serde = { version = "1.0.208", features = ["derive", "alloc", "rc"] }
-serde_json = "1.0.125"
-toml = "0.8.19"
-tokio = { version = "1.39.3", features = ["full"] }
-tracing = "0.1.40"
-tracing-subscriber = { version = "0.3.18", features = ["env-filter", "std"] }
-semver = "1.0.23"
-bitflags = { version = "2.6.0", features = ["serde", "std"] }
-reqwest = { version = "0.12.7", default-features = false, features = [
+serde = { version = "1.0", features = ["derive", "alloc", "rc"] }
+serde_json = "1.0"
+toml = "0.8"
+tokio = { version = "1.39", features = ["full"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "std"] }
+semver = "1.0"
+bitflags = { version = "2.6", features = ["serde", "std"] }
+reqwest = { version = "0.12", default-features = false, features = [
   "rustls-tls",
   "gzip",
   "json",
 ] }
-minijinja = { version = "2.1.2", features = ["loader"] }
-clap = { version = "4.5.16", features = ["derive"] }
-futures = "0.3.30"
-anyhow = "1.0.86"
-nixpkgs-fmt = "1.3.0"
-redb = "2.1.1"
-thiserror = "1.0.63"
-lazy-regex = "3.2.0"
-chrono = "0.4.38"
+minijinja = { version = "2.1", features = ["loader"] }
+clap = { version = "4.5", features = ["derive"] }
+futures = "0.3"
+anyhow = "1.0"
+nixpkgs-fmt = "1.3"
+redb = "2.1"
+thiserror = "1.0"
+lazy-regex = "3.2"
+chrono = "0.4"
 derive = { path = "./derive" }
-lazy_static = "1.5.0"
-rust-embed = "8.5.0"
+lazy_static = "1.5"
+rust-embed = "8.5"


### PR DESCRIPTION
It seems like I get *way too many* dependency update notifications for this repository. I have edited the version requirements in `Cargo.toml` to be less-specific. We should rely on `Cargo.lock` to provide exact versions.

I am truly sorry that I never contributed to this project. Maybe some day.