### PR TITLE
locense -> license

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -6,4 +6,10 @@ in rustPlatform.buildRustPackage {
   cargoLock.lockFile = "${sourceRoot}/Cargo.lock";
   src = lib.cleanSource sourceRoot;
   strictDeps = true;
+  meta = {
+    inherit (manifest.package) description homepage;
+    license = lib.licenses.asl20;
+    platforms = lib.platforms.unix;
+    mainProgram = manifest.package.name;
+  };
 }


### PR DESCRIPTION
Sorry, glad I noticed. It passed `nix flake check`.