### PR TITLE
Remove elided arguments from Nix package function

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,4 +1,4 @@
-{ sourceRoot ? ../., lib, rustPlatform, ... }:
+{ sourceRoot ? ../., lib, rustPlatform }:
 let manifest = lib.importTOML "${sourceRoot}/Cargo.toml";
 in rustPlatform.buildRustPackage {
   pname = manifest.package.name;


### PR DESCRIPTION
A package is a function which should be passed to `pkgs.callPackage`. It should not have elided (`{ ... }`) arguments.