### PR TITLE
feat(overlays): Expose utilities under nix4vscode namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Now, if you use VSCode with Home Manager, and you added overlays, you can instal
     programs.vscode = {
         enable = true;
         enableUpdateCheck = false; # Disable VSCode self-update and let Home Manager to manage VSCode versions instead.
-        enableExtensionUpdateCheck = false; # Disable extensions auto-update and let nix-vscode-extensions and nix4vscode manage updates and extensions
+        enableExtensionUpdateCheck = false; # Disable extensions auto-update and let nix4vscode manage updates and extensions
         extensions = pkgs.nix4vscode.forVscode [ "biomejs.biome" "astro-build.astro-vscode" /* ... */ ];
     };
 }

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ nix4vscode has **experimental** support for Nix overlays, here's how you can use
         };
 
         # Now you can access nix4vscode utilities from pkgs.nix4vscode
-        extensions = pkgs.nix4vscode.forVscode [ "biomejs.biome" "astro-build.astro-vscode" /* ... */ ];
+        extensions = pkgs.nix4vscode.forVscode [ "tamasfe.even-better-toml" "ms-vscode-remote.remote-containers" /* ... */ ];
     in
     {
         # ... your flake outputs
@@ -121,7 +121,10 @@ Now, if you use VSCode with Home Manager, and you added overlays, you can instal
         enable = true;
         enableUpdateCheck = false; # Disable VSCode self-update and let Home Manager to manage VSCode versions instead.
         enableExtensionUpdateCheck = false; # Disable extensions auto-update and let nix4vscode manage updates and extensions
-        extensions = pkgs.nix4vscode.forVscode [ "biomejs.biome" "astro-build.astro-vscode" /* ... */ ];
+        extensions = pkgs.nix4vscode.forVscode [
+            "tamasfe.even-better-toml"
+            "ms-vscode-remote.remote-containers.0.397.0" # You can also install specific version of extensions
+        ];
     };
 }
 ```

--- a/flake.nix
+++ b/flake.nix
@@ -127,15 +127,14 @@
       overlays = {
         default = lib.composeManyExtensions [ self.overlays.${packageName} ];
         forVscode = (
-          final: _:
-          let
-            lib = {
+          final: _: {
+            ${packageName} = {
               forVscode = customeLib.${final.system}.forVscode;
               forVscodeVersion = customeLib.${final.system}.forVscodeVersion;
               forVscodePrerelease = customeLib.${final.system}.forVscodePrerelease;
               forVscodeVersionPrerelease = customeLib.${final.system}.forVscodeVersionPrerelease;
             };
-          in lib // { ${packageName} = lib; }
+          }
         );
         ${packageName} =
           final: _:

--- a/flake.nix
+++ b/flake.nix
@@ -127,12 +127,15 @@
       overlays = {
         default = lib.composeManyExtensions [ self.overlays.${packageName} ];
         forVscode = (
-          final: _: {
-            forVscode = customeLib.${final.system}.forVscode;
-            forVscodeVersion = customeLib.${final.system}.forVscodeVersion;
-            forVscodePrerelease = customeLib.${final.system}.forVscodePrerelease;
-            forVscodeVersionPrerelease = customeLib.${final.system}.forVscodeVersionPrerelease;
-          }
+          final: _:
+          let
+            lib = {
+              forVscode = customeLib.${final.system}.forVscode;
+              forVscodeVersion = customeLib.${final.system}.forVscodeVersion;
+              forVscodePrerelease = customeLib.${final.system}.forVscodePrerelease;
+              forVscodeVersionPrerelease = customeLib.${final.system}.forVscodeVersionPrerelease;
+            };
+          in lib // { ${packageName} = lib; }
         );
         ${packageName} =
           final: _:


### PR DESCRIPTION
### Details

This PR adds re-exports utilities under the `nix4vscode` from overlays.

I wasn't sure how I can deprecate the way you expose utilities now, so I just keep them untouched, for convenience, but we should warn from using them outside of `nix4vscode` namespace, so users will be aware of the upcoming change.

I also added documentation for overlays and I think you need to improvements documentation overall. I couldn't figure out how to use it without cloning the repo and running it via cargo, so at least *I* had a problem.

### Changes

- [x] Add `nix4vscode` namespace in `forVscode` overlay;
- [x] Add usage examples for overlays;