### PR TITLE
fix warning: pkgs.system replaced by pkgs.stdenv.hostPlatform.system

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -153,12 +153,12 @@
       overlays = {
         default = (
           final: _: {
-            nix4vscode = self.lib.${final.system};
+            nix4vscode = self.lib.${final.stdenv.hostPlatform.system};
           }
         );
         forVscode = (
           final: _: {
-            nix4vscode = self.lib.${final.system};
+            nix4vscode = self.lib.${final.stdenv.hostPlatform.system};
           }
         );
       };

--- a/nix/forVscodeVersionRaw.nix
+++ b/nix/forVscodeVersionRaw.nix
@@ -8,7 +8,9 @@
   isOpenVsx ? false,
 }:
 let
-  inherit (pkgs) lib system;
+  inherit (pkgs) lib;
+  system = pkgs.stdenv.hostPlatform.system;
+
   matchesVscodeVersion = import ./matchesVscodeVersion.nix lib version;
   allExtensions = lib.importJSON dataPath;
   platformMap = {


### PR DESCRIPTION
Addresses a warning due to the deprecation of pkgs.system in https://github.com/NixOS/nixpkgs/pull/456527