### PR TITLE
Add Dependabot for nix flake updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,3 +21,8 @@ updates:
     directory: "/derive"
     schedule:
       interval: "monthly"
+
+  - package-ecosystem: "nix"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
See https://github.blog/changelog/2026-04-07-dependabot-version-updates-now-support-the-nix-ecosystem/