### PR TITLE
refactor(code-api): use XIDL generated gallery client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -446,6 +446,7 @@ dependencies = [
  "itertools",
  "lazy-regex",
  "reqwest",
+ "rustls",
  "serde",
  "serde_json",
  "serde_with",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,13 +90,13 @@ checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
 
 [[package]]
 name = "async-compression"
-version = "0.4.25"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40f6024f3f856663b45fd0c9b6f2024034a702f453549449e0d84a305900dad4"
+checksum = "5a89bce6054c720275ac2432fbba080a66a2106a44a1b804553930ca6909f4e0"
 dependencies = [
- "flate2",
+ "compression-codecs",
+ "compression-core",
  "futures-core",
- "memchr",
  "pin-project-lite",
  "tokio",
 ]
@@ -135,10 +135,128 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core",
+ "axum-macros",
+ "base64",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sha1",
+ "sync_wrapper",
+ "tokio",
+ "tokio-tungstenite 0.29.0",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-extra"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9963ff19f40c6102c76756ef0a46004c0d58957d87259fc9208ff8441c12ab96"
+dependencies = [
+ "axum",
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "headers",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "serde_core",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-macros"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7aa268c23bfbbd2c4363b9cd302a4f504fb2a9dfe7e3451d66f35dd392e20aca"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "base16ct"
@@ -160,9 +278,9 @@ checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 dependencies = [
  "serde_core",
 ]
@@ -231,10 +349,13 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.27"
+version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d487aa071b5f64da6f19a3e848e3578944b726ee5a4854b82172f02aa876bfdc"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
+ "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -305,6 +426,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "code-api"
 version = "0.0.11"
 dependencies = [
@@ -321,6 +451,7 @@ dependencies = [
  "serde_with",
  "tracing",
  "xidl-build",
+ "xidl-rust-axum",
 ]
 
 [[package]]
@@ -328,6 +459,33 @@ name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
+name = "compression-codecs"
+version = "0.4.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef8a506ec4b81c460798f572caead636d57d3d7e940f998160f52bd254bf2d23"
+dependencies = [
+ "compression-core",
+ "flate2",
+ "memchr",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e47641d3deaf41fb1538ac1f54735925e275eaf3bf4d55c81b137fba797e5cbb"
 
 [[package]]
 name = "const-oid"
@@ -342,6 +500,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "affbf0190ed2caf063e3def54ff444b449371d55c58e513a95ab98eca50adb49"
 dependencies = [
  "unicode-segmentation",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -371,9 +539,9 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
@@ -496,6 +664,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -610,6 +784,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -681,6 +861,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "enum_dispatch"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -739,10 +928,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
-name = "flate2"
-version = "1.1.2"
+name = "find-msvc-tools"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -762,6 +957,12 @@ checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -902,6 +1103,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap 2.10.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -918,6 +1138,30 @@ name = "hashbrown"
 version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
+
+[[package]]
+name = "headers"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb"
+dependencies = [
+ "base64",
+ "bytes",
+ "headers-core",
+ "http",
+ "httpdate",
+ "mime",
+ "sha1",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
+dependencies = [
+ "http",
+]
 
 [[package]]
 name = "heck"
@@ -990,6 +1234,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hybrid-array"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1000,16 +1250,19 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.6.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
+ "atomic-waker",
  "bytes",
  "futures-channel",
- "futures-util",
+ "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -1033,7 +1286,6 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
 ]
 
 [[package]]
@@ -1068,9 +1320,11 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2 0.5.10",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -1258,16 +1512,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
-name = "iri-string"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbc5ebe9c3a1a7a5127f920a418f7585e9e758e911d0466ed004f393b0e380b2"
-dependencies = [
- "memchr",
- "serde",
-]
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1330,12 +1574,72 @@ dependencies = [
 ]
 
 [[package]]
-name = "js-sys"
-version = "0.3.82"
+name = "jni"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b011eec8cc36da2aab2d5cff675ec18454fad408585853910a202391cf9f8e65"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
 dependencies = [
- "once_cell",
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror",
+ "walkdir",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.3",
+ "libc",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2025f20d7a4fa7785846e7b63d10a76d3f1cee98ee5cb79ea59703f95e42162"
+dependencies = [
+ "cfg-if",
+ "futures-util",
  "wasm-bindgen",
 ]
 
@@ -1460,6 +1764,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "md5"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1500,6 +1810,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
 name = "minijinja"
 version = "2.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1516,6 +1832,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -1887,6 +2204,7 @@ version = "0.11.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49df843a9161c85bb8aae55f101bc0bac8bcafd637a620d9122fd7e0b2f7422e"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.3.3",
  "lru-slab",
@@ -2050,15 +2368,16 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
-version = "0.12.23"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d429f34c8092b2d42c7c93cec323bb4adeb7c67698f70839adec842ec10c7ceb"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
- "async-compression",
  "base64",
  "bytes",
+ "encoding_rs",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "http-body-util",
@@ -2067,14 +2386,15 @@ dependencies = [
  "hyper-util",
  "js-sys",
  "log",
+ "mime",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
  "rustls",
  "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
- "serde_urlencoded",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
@@ -2085,8 +2405,8 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
- "webpki-roots",
 ]
 
 [[package]]
@@ -2154,6 +2474,7 @@ version = "0.23.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7160e3e10bf4535308537f3c4e1641468cd0e485175d6163087c0393c7d46643"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -2186,11 +2507,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.103.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4a72fe2bcf7a6ac6fd7d0b9e5cb68aeb7d4c0a0271730218b3e92d43b4eb435"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -2207,6 +2556,15 @@ name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "schannel"
@@ -2272,12 +2630,12 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "3.2.0"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -2285,9 +2643,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.14.0"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2358,6 +2716,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_plain"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce1fc6db65a611022b23a0dec6975d63fb80a302cb3388835ff02c097258d50"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2410,6 +2777,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2431,9 +2809,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook-registry"
@@ -2453,6 +2831,28 @@ dependencies = [
  "digest",
  "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "simple_asn1"
@@ -2606,6 +3006,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2738,6 +3159,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.28.0",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.29.0",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2821,21 +3266,26 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.6"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
+ "async-compression",
  "bitflags",
  "bytes",
+ "futures-core",
  "futures-util",
  "http",
  "http-body",
- "iri-string",
+ "http-body-util",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",
  "tracing",
+ "url",
 ]
 
 [[package]]
@@ -2971,6 +3421,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.1",
+ "sha1",
+ "thiserror",
+ "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.1",
+ "sha1",
+ "thiserror",
+]
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3013,6 +3496,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3043,6 +3532,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3068,9 +3567,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.105"
+version = "0.2.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da95793dfc411fbbd93f5be7715b0578ec61fe87cb1a42b12eb625caa5c5ea60"
+checksum = "a254a4b10c19a76f09a27640e7ffbf9bc30bf67e16a3bf28aaefa4920fe81563"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3081,22 +3580,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.55"
+version = "0.4.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "551f88106c6d5e7ccc7cd9a16f312dd3b5d36ea8b4954304657d5dfba115d4a0"
+checksum = "54568702fabf5d4849ce2b90fadfa64168a097eaf4b351ce9df8b687a0086aaf"
 dependencies = [
- "cfg-if",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.105"
+version = "0.2.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04264334509e04a7bf8690f2384ef5265f05143a4bff3889ab7a3269adab59c2"
+checksum = "24a40fc75b0ec6f3746ceb10d36f53a93dcd68a93b11b6445983945d79eba0dc"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3104,9 +3600,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.105"
+version = "0.2.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "420bc339d9f322e562942d52e115d57e950d12d88983a14c79b86859ee6c7ebc"
+checksum = "908f34bd9b9ce3d4caf07b72dfab63d61504d156856c6bd3cd87fa350cf3985b"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3117,18 +3613,31 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.105"
+version = "0.2.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76f218a38c84bcb33c25ec7059b07847d465ce0e0a76b995e134a45adcb6af76"
+checksum = "7acbf7616c27b194bbb550bf77ed0c2c3e5b7fd1260a93082b95fb7f47959b92"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
-name = "web-sys"
-version = "0.3.82"
+name = "wasm-streams"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a1f95c0d03a47f4ae1f7a64643a6bb97465d9b740f0fa8f90ea33915c99a9a1"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e0871acf327f283dc6da28a1696cdc64fb355ba9f935d052021fa77f35cce69"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3146,10 +3655,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki-roots"
-version = "1.0.1"
+name = "webpki-root-certs"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8782dd5a41a24eed3a4f40b606249b3e236ca61adf1f25ea4d45c73de122b502"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -3209,6 +3718,17 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-registry"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
+dependencies = [
+ "windows-link 0.1.3",
+ "windows-result",
+ "windows-strings",
+]
 
 [[package]]
 name = "windows-result"
@@ -3401,6 +3921,30 @@ dependencies = [
  "quote",
  "syn",
  "tree-sitter-idl",
+]
+
+[[package]]
+name = "xidl-rust-axum"
+version = "0.77.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afe878b4e683b87fec26e62e56bed807388586afcaa8e159f727c22aa408a6c8"
+dependencies = [
+ "axum",
+ "axum-extra",
+ "base64",
+ "futures-util",
+ "hyper",
+ "hyper-util",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "serde_plain",
+ "serde_urlencoded",
+ "thiserror",
+ "tokio",
+ "tokio-tungstenite 0.28.0",
+ "tokio-util",
+ "tower-http",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,9 +125,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.88"
+version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -240,9 +240,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.1"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
@@ -320,6 +320,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tracing",
+ "xidl-build",
 ]
 
 [[package]]
@@ -333,6 +334,15 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "convert_case"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "affbf0190ed2caf063e3def54ff444b449371d55c58e513a95ab98eca50adb49"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "core-foundation"
@@ -367,6 +377,12 @@ checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crown"
@@ -463,6 +479,20 @@ dependencies = [
  "darling_core",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "dashmap"
+version = "6.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -648,6 +678,18 @@ dependencies = [
  "sec1",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "enum_dispatch"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa18ce2bc66555b3218614519ac839ddb759a7d6720732f979ef8d13be147ecd"
+dependencies = [
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -864,6 +906,12 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -1163,6 +1211,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "include_dir"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "923d117408f1e49d914f1a379a309cffe4f18c05cf4e3d12e613a15fc81bd0dd"
+dependencies = [
+ "include_dir_macros",
+]
+
+[[package]]
+name = "include_dir_macros"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1220,6 +1287,47 @@ name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "jiff"
+version = "0.2.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4603d3033e49e2b0e31229fcab20a5d40089c607d975cd9c80551dc69eed9102"
+dependencies = [
+ "jiff-static",
+ "jiff-tzdb-platform",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "782d32378dddf207193ac91cefb848ad41abb58195c95168e1291227a0832b47"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c900ef84826f1338a557697dc8fc601df9ca9af4ac137c7fb61d4c6f2dfd3076"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
+]
 
 [[package]]
 name = "js-sys"
@@ -1352,10 +1460,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "md5"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae960838283323069879657ca3de837e9f7bbb4c7bf6ea7f1b290d5e9476d2e0"
+
+[[package]]
 name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+
+[[package]]
+name = "memo-map"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38d1115007560874e373613744c6fba374c17688327a71c1476d1a5954cc857b"
+
+[[package]]
+name = "miette"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f98efec8807c63c752b5bd61f862c165c115b0a35685bdcfd9238c7aeb592b7"
+dependencies = [
+ "cfg-if",
+ "miette-derive",
+ "unicode-width",
+]
+
+[[package]]
+name = "miette-derive"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "minijinja"
+version = "2.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2929e494b2280e1e18959bb2e121da03347ae896896fdfaceaab43c88a02803f"
+dependencies = [
+ "memo-map",
+ "serde",
+]
 
 [[package]]
 name = "miniz_oxide"
@@ -1499,9 +1651,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -1651,6 +1803,21 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "potential_utf"
@@ -2172,6 +2339,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
+ "indexmap 2.10.0",
  "itoa",
  "memchr",
  "serde",
@@ -2387,6 +2555,12 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520"
 
 [[package]]
 name = "strsim"
@@ -2739,6 +2913,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19bcada1000487b94b3858dbcf935f039dc898ed82fe7aa9ef9db01aa423af6e"
+dependencies = [
+ "cc",
+ "regex",
+ "regex-syntax",
+ "serde_json",
+ "streaming-iterator",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-idl"
+version = "3.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea80964f7b042272d2f356515f3ce5a3c2658f979c57e9fb1b385484adaff8f"
+dependencies = [
+ "cc",
+ "tree-sitter",
+]
+
+[[package]]
+name = "tree-sitter-language"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2777,6 +2981,18 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "untrusted"
@@ -3126,6 +3342,95 @@ name = "writeable"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
+
+[[package]]
+name = "xidl-build"
+version = "0.77.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09418387c1c89f626ee3e20647102172239b63cb7228005cb80c453e66239515"
+dependencies = [
+ "tokio",
+ "xidlc",
+]
+
+[[package]]
+name = "xidl-jsonrpc"
+version = "0.77.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d6477edd8cb740aaf2ce02a96e76db548f88db6b42e0ac0c0171805790a90e2"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "dashmap",
+ "futures-core",
+ "futures-util",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
+name = "xidl-parser"
+version = "0.77.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0104a76832240b53c595365bffbc6209dd44efe57c66bac27d2484875efae4fe"
+dependencies = [
+ "convert_case",
+ "include_dir",
+ "jiff",
+ "md5",
+ "minijinja",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tree-sitter",
+ "tree-sitter-idl",
+ "xidl-parser-derive",
+]
+
+[[package]]
+name = "xidl-parser-derive"
+version = "0.77.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8557da82c7b2efdb85f2e6d28266bb2c0d687d316c41fabcbd5a18c4748b2433"
+dependencies = [
+ "convert_case",
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "tree-sitter-idl",
+]
+
+[[package]]
+name = "xidlc"
+version = "0.77.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afdd1a745339c96a623c3f9db1fc37ee088d0420b2da8d2164d5ea7a572b8409"
+dependencies = [
+ "async-trait",
+ "convert_case",
+ "enum_dispatch",
+ "include_dir",
+ "indexmap 2.10.0",
+ "itertools",
+ "jiff",
+ "md5",
+ "miette",
+ "minijinja",
+ "scopeguard",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "tree-sitter",
+ "tree-sitter-idl",
+ "xidl-jsonrpc",
+ "xidl-parser",
+]
 
 [[package]]
 name = "yoke"

--- a/crates/code_api/Cargo.toml
+++ b/crates/code_api/Cargo.toml
@@ -14,6 +14,7 @@ serde_json = { workspace = true }
 chrono = { workspace = true }
 lazy-regex = { workspace = true }
 reqwest = { version = "0.13", features = ["gzip"] }
+rustls = { version = "0.23", features = ["aws_lc_rs"] }
 xidl-rust-axum = "0.77.0"
 
 itertools = "0.14.0"

--- a/crates/code_api/Cargo.toml
+++ b/crates/code_api/Cargo.toml
@@ -21,3 +21,6 @@ reqwest = { version = "0.12", default-features = false, features = [
 
 itertools = "0.14.0"
 serde_with = "3.17.0"
+
+[build-dependencies]
+xidl-build = "0.77.0"

--- a/crates/code_api/Cargo.toml
+++ b/crates/code_api/Cargo.toml
@@ -13,11 +13,8 @@ async-stream = "0.3"
 serde_json = { workspace = true }
 chrono = { workspace = true }
 lazy-regex = { workspace = true }
-reqwest = { version = "0.12", default-features = false, features = [
-  "rustls-tls",
-  "gzip",
-  "json",
-] }
+reqwest = { version = "0.13", features = ["gzip"] }
+xidl-rust-axum = "0.77.0"
 
 itertools = "0.14.0"
 serde_with = "3.17.0"

--- a/crates/code_api/build.rs
+++ b/crates/code_api/build.rs
@@ -1,9 +1,16 @@
 fn main() -> Result<(), xidl_build::IdlcError> {
     println!("cargo:rerun-if-changed=idl/gallery.idl");
+    println!("cargo:rerun-if-changed=idl/gallery_support.idl");
+
+    xidl_build::Builder::new()
+        .with_lang("rust-axum")
+        .with_server(false)
+        .with_client(true)
+        .compile(&["idl/gallery.idl"])?;
 
     xidl_build::Builder::new()
         .with_lang("rust")
-        .compile(&["idl/gallery.idl"])?;
+        .compile(&["idl/gallery_support.idl"])?;
 
     Ok(())
 }

--- a/crates/code_api/build.rs
+++ b/crates/code_api/build.rs
@@ -1,0 +1,9 @@
+fn main() -> Result<(), xidl_build::IdlcError> {
+    println!("cargo:rerun-if-changed=idl/gallery.idl");
+
+    xidl_build::Builder::new()
+        .with_lang("rust")
+        .compile(&["idl/gallery.idl"])?;
+
+    Ok(())
+}

--- a/crates/code_api/idl/gallery.idl
+++ b/crates/code_api/idl/gallery.idl
@@ -1,6 +1,6 @@
-@rename_all("camelCase")
 struct Query {
     sequence<IQueryState> filters;
+    @rename("assetTypes")
     sequence<string> asset_types;
     unsigned long flags;
 };
@@ -17,86 +17,98 @@ interface GalleryService {
     );
 };
 
-@rename_all("camelCase")
 struct IRawGalleryQueryResult {
     sequence<IRawGalleryExtensionsResult> results;
 };
 
-@rename_all("camelCase")
 struct IRawGalleryExtensionStatistics {
+    @rename("statisticName")
     string statistic_name;
     double value;
 };
 
-@rename_all("camelCase")
 struct IRawGalleryExtensionPublisher {
+    @optional
+    @rename("displayName")
     string display_name;
     @optional
+    @rename("publisherId")
     string publisher_id;
+    @rename("publisherName")
     string publisher_name;
     @optional
     string domain;
 };
 
-@rename_all("camelCase")
 struct IRawGalleryExtension {
     @optional
+    @rename("extensionId")
     string extension_id;
+    @rename("extensionName")
     string extension_name;
     @optional
+    @rename("displayName")
     string display_name;
     @optional
+    @rename("shortDescription")
     string short_description;
     IRawGalleryExtensionPublisher publisher;
     sequence<IRawGalleryExtensionVersion> versions;
+    @optional
     sequence<IRawGalleryExtensionStatistics> statistics;
+    @rename("releaseDate")
     string release_date;
+    @rename("publishedDate")
     string published_date;
+    @rename("lastUpdated")
     string last_updated;
     @optional
     sequence<string> categories;
     string flags;
 };
 
-@rename_all("camelCase")
 struct IRawGalleryExtensionsResult {
     sequence<IRawGalleryExtension> extensions;
+    @rename("resultMetadata")
     sequence<ResultMetaData> result_metadata;
 };
 
-@rename_all("camelCase")
 struct IRawGalleryExtensionVersion {
     string version;
+    @rename("lastUpdated")
     string last_updated;
+    @rename("assetUri")
     string asset_uri;
+    @rename("fallbackAssetUri")
     string fallback_asset_uri;
     @optional
     sequence<IRawGalleryExtensionFile> files;
+    @optional
     sequence<IRawGalleryExtensionProperty> properties;
     @optional
+    @rename("targetPlatform")
     string target_platform;
 };
 
-@rename_all("camelCase")
 struct IRawGalleryExtensionProperty {
     string key;
     string value;
 };
 
-@rename_all("camelCase")
 struct IRawGalleryExtensionFile {
+    @rename("assetType")
     string asset_type;
     string source;
 };
 
-@rename_all("camelCase")
 struct MetaDataItem {
     string name;
     unsigned long long count;
 };
 
-@rename_all("camelCase")
 struct ResultMetaData {
+    @rename("metadataType")
     string metadata_type;
+    @rename("metadataItems")
     sequence<MetaDataItem> metadata_items;
 };

--- a/crates/code_api/idl/gallery.idl
+++ b/crates/code_api/idl/gallery.idl
@@ -1,0 +1,83 @@
+@rename_all("camelCase")
+struct IRawGalleryQueryResult {
+    sequence<IRawGalleryExtensionsResult> results;
+};
+
+@rename_all("camelCase")
+struct IRawGalleryExtensionStatistics {
+    string statistic_name;
+    double value;
+};
+
+@rename_all("camelCase")
+struct IRawGalleryExtensionPublisher {
+    string display_name;
+    @optional
+    string publisher_id;
+    string publisher_name;
+    @optional
+    string domain;
+};
+
+@rename_all("camelCase")
+struct IRawGalleryExtension {
+    @optional
+    string extension_id;
+    string extension_name;
+    @optional
+    string display_name;
+    @optional
+    string short_description;
+    IRawGalleryExtensionPublisher publisher;
+    sequence<IRawGalleryExtensionVersion> versions;
+    sequence<IRawGalleryExtensionStatistics> statistics;
+    string release_date;
+    string published_date;
+    string last_updated;
+    @optional
+    sequence<string> categories;
+    string flags;
+};
+
+@rename_all("camelCase")
+struct IRawGalleryExtensionsResult {
+    sequence<IRawGalleryExtension> extensions;
+    sequence<ResultMetaData> result_metadata;
+};
+
+@rename_all("camelCase")
+struct IRawGalleryExtensionVersion {
+    string version;
+    string last_updated;
+    string asset_uri;
+    string fallback_asset_uri;
+    @optional
+    sequence<IRawGalleryExtensionFile> files;
+    sequence<IRawGalleryExtensionProperty> properties;
+    @optional
+    string target_platform;
+};
+
+@rename_all("camelCase")
+struct IRawGalleryExtensionProperty {
+    string key;
+    string value;
+};
+
+@rename_all("camelCase")
+struct IRawGalleryExtensionFile {
+    string asset_type;
+    string source;
+};
+
+@rename_all("camelCase")
+struct MetaDataItem {
+    string name;
+    unsigned long long count;
+};
+
+@rename_all("camelCase")
+struct ResultMetaData {
+    string metadata_type;
+    sequence<MetaDataItem> metadata_items;
+};

--- a/crates/code_api/idl/gallery.idl
+++ b/crates/code_api/idl/gallery.idl
@@ -1,4 +1,23 @@
 @rename_all("camelCase")
+struct Query {
+    sequence<IQueryState> filters;
+    sequence<string> asset_types;
+    unsigned long flags;
+};
+
+interface GalleryService {
+    @post(path = "/extensionquery")
+    IRawGalleryQueryResult extension_query(
+        @header @rename("Accept")
+        string accept,
+        @header @rename("Accept-Encoding")
+        string accept_encoding,
+        @flatten
+        Query query
+    );
+};
+
+@rename_all("camelCase")
 struct IRawGalleryQueryResult {
     sequence<IRawGalleryExtensionsResult> results;
 };

--- a/crates/code_api/idl/gallery_support.idl
+++ b/crates/code_api/idl/gallery_support.idl
@@ -1,0 +1,24 @@
+@rename_all("camelCase")
+struct ICriterium {
+    FilterType filter_type;
+    string value;
+};
+
+@rename_all("kebab-case")
+@derive(Hash)
+enum TargetPlatform {
+    Win32X64,
+    Win32Ia32,
+    Win32Arm64,
+    LinuxX64,
+    LinuxArm64,
+    LinuxArmhf,
+    AlpineX64,
+    AlpineArm64,
+    DarwinX64,
+    DarwinArm64,
+    Universal,
+    Web,
+    Unknown,
+    Undefined,
+};

--- a/crates/code_api/idl/gallery_support.idl
+++ b/crates/code_api/idl/gallery_support.idl
@@ -1,21 +1,30 @@
-@rename_all("camelCase")
 struct ICriterium {
+    @rename("filterType")
     FilterType filter_type;
     string value;
 };
 
-@rename_all("kebab-case")
 @derive(Hash)
 enum TargetPlatform {
+    @rename("win32-x64")
     Win32X64,
+    @rename("win32-ia32")
     Win32Ia32,
+    @rename("win32-arm64")
     Win32Arm64,
+    @rename("linux-x64")
     LinuxX64,
+    @rename("linux-arm64")
     LinuxArm64,
+    @rename("linux-armhf")
     LinuxArmhf,
+    @rename("alpine-x64")
     AlpineX64,
+    @rename("alpine-arm64")
     AlpineArm64,
+    @rename("darwin-x64")
     DarwinX64,
+    @rename("darwin-arm64")
     DarwinArm64,
     Universal,
     Web,

--- a/crates/code_api/src/code.rs
+++ b/crates/code_api/src/code.rs
@@ -9,17 +9,25 @@ mod request_body;
 mod version;
 
 mod generated {
+    use super::IQueryState;
+
     include!(concat!(env!("OUT_DIR"), "/gallery.rs"));
 }
 
 pub use generated::*;
 
-pub use extensions::*;
+mod generated_support {
+    use super::FilterType;
+
+    include!(concat!(env!("OUT_DIR"), "/gallery_support.rs"));
+}
+
+pub use generated_support::*;
+
 pub use gallery_extension::*;
 
 pub use enums::*;
 pub use flags::*;
 pub use http_client::*;
-pub use query::*;
 pub use request_body::*;
 pub use version::*;

--- a/crates/code_api/src/code.rs
+++ b/crates/code_api/src/code.rs
@@ -8,6 +8,12 @@ mod query;
 mod request_body;
 mod version;
 
+mod generated {
+    include!(concat!(env!("OUT_DIR"), "/gallery.rs"));
+}
+
+pub use generated::*;
+
 pub use extensions::*;
 pub use gallery_extension::*;
 

--- a/crates/code_api/src/code/enums.rs
+++ b/crates/code_api/src/code/enums.rs
@@ -1,6 +1,6 @@
 use std::fmt::Display;
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone)]
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(default)]
 #[serde(rename_all = "camelCase")]
 pub struct FilterType(u8);
@@ -72,7 +72,7 @@ impl From<&PropertyType> for &str {
     }
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, Default)]
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, Default, PartialEq, Eq)]
 #[serde(default)]
 #[serde(rename_all = "camelCase")]
 pub struct SortOrder(u8);
@@ -83,7 +83,7 @@ impl SortOrder {
     pub const DESCENDING: Self = Self(2);
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, Default)]
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, Default, PartialEq, Eq)]
 #[serde(default)]
 #[serde(rename_all = "camelCase")]
 pub struct SortBy(u8);

--- a/crates/code_api/src/code/extensions.rs
+++ b/crates/code_api/src/code/extensions.rs
@@ -48,22 +48,6 @@ impl From<&str> for TargetPlatform {
     }
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, Default)]
-#[serde(default)]
-#[serde(rename_all = "camelCase")]
-pub struct MetaDataItem {
-    pub name: String,
-    pub count: u64,
-}
-
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, Default)]
-#[serde(default)]
-#[serde(rename_all = "camelCase")]
-pub struct ResultMetaData {
-    pub metadata_type: String,
-    pub metadata_items: Vec<MetaDataItem>,
-}
-
 #[cfg(test)]
 mod test {
     use super::*;

--- a/crates/code_api/src/code/extensions.rs
+++ b/crates/code_api/src/code/extensions.rs
@@ -1,30 +1,5 @@
-use serde::{Deserialize, Serialize};
-
 // https://github.com/microsoft/vscode/blob/d187d50a482ff80dcf74c35affb09dda1a7cd2fe/src/vs/platform/extensions/common/extensions.ts
-#[derive(Debug, Serialize, Deserialize, Clone, Copy, Hash, Eq, PartialEq)]
-#[serde(rename_all = "kebab-case")]
-pub enum TargetPlatform {
-    Win32X64,
-    Win32Ia32,
-    Win32Arm64,
-
-    LinuxX64,
-    LinuxArm64,
-    LinuxArmhf,
-
-    AlpineX64,
-    AlpineArm64,
-
-    DarwinX64,
-    DarwinArm64,
-    // darwin universal
-    Universal,
-
-    // https://code.visualstudio.com/api/extension-guides/web-extensions
-    Web,
-    Unknown,
-    Undefined,
-}
+use super::TargetPlatform;
 
 impl From<&str> for TargetPlatform {
     fn from(value: &str) -> Self {

--- a/crates/code_api/src/code/gallery_extension.rs
+++ b/crates/code_api/src/code/gallery_extension.rs
@@ -2,54 +2,9 @@ mod extension_version;
 mod version;
 use std::fmt::Display;
 
-pub use extension_version::*;
 pub use version::*;
 
-use super::{ResultMetaData, TargetPlatform};
-
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, Default)]
-#[serde(default)]
-#[serde(rename_all = "camelCase")]
-pub struct IRawGalleryQueryResult {
-    pub results: Vec<IRawGalleryExtensionsResult>,
-}
-
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, Default)]
-#[serde(default)]
-#[serde(rename_all = "camelCase")]
-pub struct IRawGalleryExtensionStatistics {
-    pub statistic_name: String,
-    pub value: f64,
-}
-
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, Default)]
-#[serde(default)]
-#[serde(rename_all = "camelCase")]
-pub struct IRawGalleryExtensionPublisher {
-    pub display_name: String,
-    /// In openvsx, this maybe empty.
-    pub publisher_id: Option<String>,
-    pub publisher_name: String,
-    pub domain: Option<String>,
-}
-
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, Default)]
-#[serde(default)]
-#[serde(rename_all = "camelCase")]
-pub struct IRawGalleryExtension {
-    pub extension_id: Option<String>,
-    pub extension_name: String,
-    pub display_name: Option<String>,
-    pub short_description: Option<String>,
-    pub publisher: IRawGalleryExtensionPublisher,
-    pub versions: Vec<IRawGalleryExtensionVersion>,
-    pub statistics: Vec<IRawGalleryExtensionStatistics>,
-    pub release_date: String,
-    pub published_date: String,
-    pub last_updated: String,
-    pub categories: Option<Vec<String>>,
-    pub flags: String,
-}
+use super::{IRawGalleryExtension, IRawGalleryExtensionsResult, TargetPlatform};
 
 impl Display for IRawGalleryExtension {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -59,14 +14,6 @@ impl Display for IRawGalleryExtension {
             self.publisher.publisher_name, self.extension_name
         )
     }
-}
-
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, Default)]
-#[serde(default)]
-#[serde(rename_all = "camelCase")]
-pub struct IRawGalleryExtensionsResult {
-    pub extensions: Vec<IRawGalleryExtension>,
-    pub result_metadata: Vec<ResultMetaData>,
 }
 
 impl IRawGalleryExtensionsResult {

--- a/crates/code_api/src/code/gallery_extension/extension_version.rs
+++ b/crates/code_api/src/code/gallery_extension/extension_version.rs
@@ -15,10 +15,12 @@ impl IRawGalleryExtensionVersion {
     pub fn get_engine(&self) -> anyhow::Result<String> {
         match self
             .properties
+            .as_deref()
+            .unwrap_or_default()
             .iter()
             .position(|item| item.key == PropertyType::Engine.to_string())
         {
-            Some(idx) => Ok(self.properties[idx].value.clone()),
+            Some(idx) => Ok(self.properties.as_ref().unwrap()[idx].value.clone()),
             None => Err(anyhow!("Missing attribute: engine")),
         }
     }
@@ -26,6 +28,8 @@ impl IRawGalleryExtensionVersion {
     pub fn is_pre_release_version(&self) -> bool {
         let values = self
             .properties
+            .as_deref()
+            .unwrap_or_default()
             .iter()
             .filter(|item| item.key == PropertyType::PRE_RELEASE)
             .collect_vec();

--- a/crates/code_api/src/code/gallery_extension/extension_version.rs
+++ b/crates/code_api/src/code/gallery_extension/extension_version.rs
@@ -1,26 +1,9 @@
 use anyhow::anyhow;
 use itertools::Itertools;
-use serde_with::DefaultOnNull;
-use serde_with::serde_as;
 
-use crate::code::PropertyType;
+use crate::code::{IRawGalleryExtensionFile, IRawGalleryExtensionVersion, PropertyType};
 
 use super::*;
-
-#[serde_as]
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, Default)]
-#[serde(default)]
-#[serde(rename_all = "camelCase")]
-pub struct IRawGalleryExtensionVersion {
-    pub version: String,
-    pub last_updated: String,
-    pub asset_uri: String,
-    pub fallback_asset_uri: String,
-    #[serde_as(deserialize_as = "DefaultOnNull")]
-    pub files: Vec<IRawGalleryExtensionFile>,
-    pub properties: Vec<IRawGalleryExtensionProperty>,
-    pub target_platform: Option<String>,
-}
 
 impl Display for IRawGalleryExtensionVersion {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -51,13 +34,9 @@ impl IRawGalleryExtensionVersion {
     }
 
     pub fn get_file(&self, file_kind: AssetType) -> Option<&IRawGalleryExtensionFile> {
-        match self
-            .files
+        self.files
+            .as_ref()?
             .iter()
-            .position(|item| item.asset_type == file_kind.to_string())
-        {
-            Some(idx) => Some(&self.files[idx]),
-            None => None,
-        }
+            .find(|item| item.asset_type == file_kind.to_string())
     }
 }

--- a/crates/code_api/src/code/gallery_extension/version.rs
+++ b/crates/code_api/src/code/gallery_extension/version.rs
@@ -1,21 +1,5 @@
 use std::fmt::Display;
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, Default)]
-#[serde(default)]
-#[serde(rename_all = "camelCase")]
-pub struct IRawGalleryExtensionProperty {
-    pub key: String,
-    pub value: String,
-}
-
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, Default)]
-#[serde(default)]
-#[serde(rename_all = "camelCase")]
-pub struct IRawGalleryExtensionFile {
-    pub asset_type: String,
-    pub source: String,
-}
-
 pub enum AssetType {
     Icon,
     Details,

--- a/crates/code_api/src/code/http_client.rs
+++ b/crates/code_api/src/code/http_client.rs
@@ -1,5 +1,5 @@
 use crate::{
-    code::{self, IRawGalleryExtensionsResult, IRawGalleryQueryResult, TargetPlatform},
+    code::{self, GalleryServiceClient, IRawGalleryExtensionsResult, TargetPlatform},
     config::Extension,
 };
 
@@ -15,22 +15,25 @@ pub enum ApiEndpoint {
     OpenVsx,
 }
 
-#[derive(Debug, Clone)]
+const ACCEPT: &str = "application/json; charset=utf-8; api-version=7.2-preview.1";
+const ACCEPT_ENCODING: &str = "gzip";
+
 pub struct HttpClient {
-    pub client: reqwest::Client,
-    pub endpoint: &'static str,
+    pub client: GalleryServiceClient,
 }
 
 impl HttpClient {
     pub fn new(endpoint: ApiEndpoint) -> anyhow::Result<Self> {
-        let client = reqwest::Client::builder().gzip(true).build()?;
-        let endpoint = match endpoint {
-            ApiEndpoint::Vscode => {
-                "https://marketplace.visualstudio.com/_apis/public/gallery/extensionquery"
-            }
-            ApiEndpoint::OpenVsx => "https://open-vsx.org/vscode/gallery/extensionquery",
+        let http = xidl_rust_axum::reqwest::Client::builder()
+            .gzip(true)
+            .build()?;
+        let base_url = match endpoint {
+            ApiEndpoint::Vscode => "https://marketplace.visualstudio.com/_apis/public/gallery",
+            ApiEndpoint::OpenVsx => "https://open-vsx.org/vscode/gallery",
         };
-        Ok(Self { client, endpoint })
+        Ok(Self {
+            client: GalleryServiceClient::with_http(base_url, http),
+        })
     }
 
     pub fn get_extension_response(
@@ -48,17 +51,7 @@ impl HttpClient {
                 trace!("send request: {body}");
                 let response = self
                     .client
-                    .post(self.endpoint)
-                    .header("CONTENT-TYPE", "application/json")
-                    .header(
-                        "ACCEPT",
-                        "application/json; charset=utf-8; api-version=7.2-preview.1",
-                    )
-                    .header("ACCEPT-ENCODING", "gzip")
-                    .body(body)
-                    .send()
-                    .await?
-                    .json::<IRawGalleryQueryResult>()
+                    .extension_query(ACCEPT.to_string(), ACCEPT_ENCODING.to_string(), query)
                     .await?;
 
                 if response.results.is_empty() {
@@ -81,18 +74,10 @@ impl HttpClient {
     ) -> anyhow::Result<IRawGalleryExtensionsResult> {
         let query = Query::create_search(publisher_name, extension_name);
         let body = serde_json::to_string(&query)?;
+        trace!("send request: {body}");
         let txt = self
             .client
-            .post("https://marketplace.visualstudio.com/_apis/public/gallery/extensionquery")
-            .header(
-                "Accept",
-                "Application/json; charset=utf-8; api-version=7.2-preview.1",
-            )
-            .header("Content-Type", "application/json")
-            .body(body)
-            .send()
-            .await?
-            .json::<code::IRawGalleryQueryResult>()
+            .extension_query(ACCEPT.to_string(), ACCEPT_ENCODING.to_string(), query)
             .await?;
         txt.results.into_iter().next().ok_or(anyhow!("Unknown"))
     }
@@ -122,7 +107,11 @@ impl HttpClient {
                     .copied()
                     .collect();
 
-                if !j.is_empty() { j } else { i }
+                if !j.is_empty() {
+                    j
+                } else {
+                    i
+                }
             }
             Err(err) => {
                 error!("Error happened when get target_platform: {err}");

--- a/crates/code_api/src/code/http_client.rs
+++ b/crates/code_api/src/code/http_client.rs
@@ -25,6 +25,7 @@ pub struct HttpClient {
 impl HttpClient {
     pub fn new(endpoint: ApiEndpoint) -> anyhow::Result<Self> {
         let http = xidl_rust_axum::reqwest::Client::builder()
+            .no_proxy()
             .gzip(true)
             .build()?;
         let base_url = match endpoint {

--- a/crates/code_api/src/code/http_client.rs
+++ b/crates/code_api/src/code/http_client.rs
@@ -24,6 +24,7 @@ pub struct HttpClient {
 
 impl HttpClient {
     pub fn new(endpoint: ApiEndpoint) -> anyhow::Result<Self> {
+        let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
         let http = xidl_rust_axum::reqwest::Client::builder()
             .no_proxy()
             .gzip(true)

--- a/crates/code_api/src/code/query.rs
+++ b/crates/code_api/src/code/query.rs
@@ -4,15 +4,6 @@ use crate::config::Extension;
 
 use super::*;
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, Default)]
-#[serde(default)]
-#[serde(rename_all = "camelCase")]
-pub struct Query {
-    pub filters: Vec<IQueryState>,
-    pub asset_types: Vec<String>,
-    pub flags: u32,
-}
-
 impl Query {
     pub fn new(extensions: &[Extension], page_number: u64, args: IQueryState) -> Self {
         let fixed = vec![

--- a/crates/code_api/src/code/request_body.rs
+++ b/crates/code_api/src/code/request_body.rs
@@ -1,14 +1,6 @@
 use super::*;
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, Default)]
-#[serde(default)]
-#[serde(rename_all = "camelCase")]
-pub struct ICriterium {
-    pub filter_type: FilterType,
-    pub value: String,
-}
-
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone)]
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq)]
 #[serde(default)]
 #[serde(rename_all = "camelCase")]
 pub struct IQueryState {

--- a/crates/code_api/src/code/version.rs
+++ b/crates/code_api/src/code/version.rs
@@ -5,7 +5,11 @@ use tracing::debug;
 
 macro_rules! texpr {
     ($ex1:expr => $ex2:expr , $ex3:expr) => {
-        if $ex1 { $ex2 } else { $ex3 }
+        if $ex1 {
+            $ex2
+        } else {
+            $ex3
+        }
     };
 }
 


### PR DESCRIPTION
## Summary
- migrate code_api gallery models and HTTP calls to xidl-build generated code
- use XIDL interface generated GalleryServiceClient for VS Code Marketplace and OpenVSX queries
- align IDL field renames and optional fields with live API responses

## Verification
- cargo fmt --check
- env -u RUSTC_WRAPPER cargo check -p code-api
- env -u RUSTC_WRAPPER cargo check
- live smoke tested VS Code Marketplace and OpenVSX gallery queries